### PR TITLE
added a delete route for highs cores

### DIFF
--- a/controllers/api/minesweeperHighscoreRoutes.js
+++ b/controllers/api/minesweeperHighscoreRoutes.js
@@ -2,46 +2,62 @@ const router = require("express").Router();
 const { User, MinesweeperHighscores } = require("../../models/index.js");
 
 router.post("/", async (req, res) => {
-	try {
-		// add back in when sessions online
-		// const user_id = req.session.user_id;
-		const user_id = 4;
+  try {
+    // add back in when sessions online
+    // const user_id = req.session.user_id;
+    const user_id = 4;
 
-		const { score } = req.body;
+    const { score } = req.body;
 
-		// checks to make sure score
-		if (!score) {
-			return res
-				.status(404)
-				.json("How do you think you're going to save a highscore without a highscore?");
-		}
+    // checks to make sure score
+    if (!score) {
+      return res
+        .status(404)
+        .json(
+          "How do you think you're going to save a highscore without a highscore?"
+        );
+    }
 
-		const newScore = await MinesweeperHighscores.create({ score, user_id });
+    const newScore = await MinesweeperHighscores.create({ score, user_id });
 
-		res.status(200).json(newScore);
-	} catch (err) {
-		res.status(500).json(err);
-	}
+    res.status(200).json(newScore);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 // get route for pulling all highscores (testing)
 router.get("/", async (req, res) => {
-	try {
-		const highscoreData = await MinesweeperHighscores.findAll({
-			attributes: ["score", "created_at", "user_id"],
-			include: [
-				{
-					model: User,
-					attributes: ["username"],
-				},
-			],
-			order: [["score", "DESC"]],
-		});
+  try {
+    const highscoreData = await MinesweeperHighscores.findAll({
+      attributes: ["score", "created_at", "user_id"],
+      include: [
+        {
+          model: User,
+          attributes: ["username"],
+        },
+      ],
+      order: [["score", "DESC"]],
+    });
 
-		res.status(200).json(highscoreData);
-	} catch (err) {
-		res.status(500).json(err);
-	}
+    res.status(200).json(highscoreData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
+});
+//creating a delete route for deleting the high scores
+router.delete("/:id", async (req, res) => {
+  try {
+    const highscoreData = await MinesweeperHighscores.destroy({
+      where: req.params.user_id,
+    });
+    if (deleteHighscore) {
+      res.status(404).json({ message: "Invalid Scores" });
+    }
+    res.status(200).json(highscoreData);
+  } catch (err) {
+    res.status(500).json(err);
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
❗ Please **DO NOT** open a Pull Request without creating an Issue first. Failure to do so will result in the rejection of the pull request.

## Purpose
Router deletes high scores 

Fixes #[issue]
Allows user to delete their high scores to restart their previous plays.

Please provide a detailed explanation of the PR. What existing problem does it solve?

## Changes
Changes were made on Controller folder in the api folder on file "minesweeperHighscores"

Please provide an overview of code changes, especially key files and areas of significant change.

path/to/file

- change
<img width="570" alt="Screen Shot 2023-03-22 at 8 50 53 PM" src="https://user-images.githubusercontent.com/122328422/227071271-881040fc-ade4-4d42-84fd-0679584584a9.png">

- change
- change

## Steps to Reproduce or Test
****Will need to be tested onces highscores are shown up in the page
Demonstrate that the pull request is functional. For example: the exact commands to be run and their output; screenshots if the PR modifies the UI.

## Optional GIF of screenshot

Self-explanatory.
